### PR TITLE
Keep user context property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,20 +12,11 @@ npm install gatsby-paginate --save
 
 * Require the package in your `gatsby-node.js` file.
 * Add a call to createPaginatedPages in `gatsby-node.js`.
-  <<<<<<< HEAD
-
-Then add the following to the top of your `gatsby-node.js` file.
-
-const createPaginatedPages = require("gatsby-paginate");
-
-````javascript
-=======
 
 Then add the following to the top of your `gatsby-node.js` file.
 
 ```javascript
 const createPaginatedPages = require("gatsby-paginate");
->>>>>>> ff0c7a0d852e8b19d063b5d3cbf305f188d0c90d
 ````
 
 ## Use case 1 - paginate list of posts on home page<a name="eg1"></a>
@@ -91,7 +82,8 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         createPage: createPage,
         pageTemplate: "src/templates/index.js",
         pageLength: 5, // This is optional and defaults to 10 if not used
-        pathPrefix: "" // This is optional and defaults to an empty sctring if not used
+        pathPrefix: "", // This is optional and defaults to an empty string if not used
+        context: {} // This is optional and defaults to an empty object if not used
       });
       result.data.posts.edges.map(({ node }) => {
         createPage({
@@ -115,6 +107,7 @@ Notice that `createPaginatedPages` is being passed an options object.
 3. `pageTemplate` is a template to use for the index page. And
 4. `pageLength` is an optional parameter that defines how many posts to show per index page. It defaults to 10.
 5. `pathPrefix` is an optional parameter for passing the name of a path to add to the path generated in the `createPage`func. This is used in [use case 2](#eg2) below.
+6. `context` is an optional parameter which is used as the `context` property when `createPage` is called. It cannot include the property `pagination`.
 
 `createPaginatedPages` will then call `createPage` to create an index page for each of the groups of pages. The content that describes the blogs (title, slug, etc) that will go in each page will be passed to the template through `props.pathContext` so you need to make sure that everything that you want on the index page regarding the blogs should be requested in the GraphQL query in `gatsby-node.js`.
 
@@ -146,9 +139,9 @@ Then a second paginated page of `your_site/your_page_name/2`
 
 ### Create the template
 
-This si a simple template which might be used in [use case 1](#eg1) above to replace the index of a blog with a paginated list of posts.
+This is a simple template which might be used in [use case 1](#eg1) above to replace the index of a blog with a paginated list of posts.
 
-The `pathContext` object which contains the following 5 keys is passed to the template;
+The `pathContext.pagination` object which contains the following 5 keys is passed to the template;
 
 1. `group` - (arr) an array containing the number of edges/nodes specified in the `pageLength` option.
 1. `index` - (int) this is the index of the edge/node.

--- a/src/index.js
+++ b/src/index.js
@@ -21,19 +21,24 @@ const isFirstPage = index => (index === 0 ? true : false);
 const isLastPage = (index, groups) =>
   index === groups.length - 1 ? true : false;
 
-const createPaginatedPages = (posts, createPage, template, pathPrefix) => {
+const createPaginatedPages = (posts, createPage, template, pathPrefix, context) => {
+  if (context.hasOwnProperty("pagination")) {
+    throw new Error("GatsbyPaginate: context has member 'pagination'");
+  }
   posts.forEach((group, index, groups) => {
     return createPage({
       path: buildPaginationRoute(getPageIndex(index), pathPrefix),
       component: template,
-      context: {
-        group,
-        pathPrefix,
-        first: isFirstPage(index),
-        last: isLastPage(index, groups),
-        index: index + 1,
-        pageCount: groups.length
-      }
+      context: Object.assign({
+        pagination: {
+          group,
+          pathPrefix,
+          first: isFirstPage(index),
+          last: isLastPage(index, groups),
+          index: index + 1,
+          pageCount: groups.length
+        }
+      }, context)
     });
   });
 };
@@ -43,13 +48,15 @@ module.exports = ({
   createPage,
   pageTemplate,
   pageLength = 10,
-  pathPrefix = ""
+  pathPrefix = "",
+  context = {}
 }) => {
   const paginationTemplate = path.resolve(pageTemplate);
   createPaginatedPages(
     filterPages(edges, pageLength),
     createPage,
     paginationTemplate,
-    pathPrefix
+    pathPrefix,
+    context
   );
 };


### PR DESCRIPTION
Adds a context property merged with pagination data and used when calling createPage.
This completely changes the structure of the pageContext object but I feel it's better in the long run.