### PR TITLE
Add buildPath option to control pagination URL structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,20 +12,13 @@ npm install gatsby-paginate --save
 
 * Require the package in your `gatsby-node.js` file.
 * Add a call to createPaginatedPages in `gatsby-node.js`.
-  <<<<<<< HEAD
 
 Then add the following to the top of your `gatsby-node.js` file.
 
 const createPaginatedPages = require("gatsby-paginate");
 
 ````javascript
-=======
-
-Then add the following to the top of your `gatsby-node.js` file.
-
-```javascript
 const createPaginatedPages = require("gatsby-paginate");
->>>>>>> ff0c7a0d852e8b19d063b5d3cbf305f188d0c90d
 ````
 
 ## Use case 1 - paginate list of posts on home page<a name="eg1"></a>
@@ -130,7 +123,8 @@ createPaginatedPages({
   createPage: createPage,
   pageTemplate: "src/templates/your_cool_template.js",
   pageLength: 5,
-  pathPrefix: "your_page_name"
+  pathPrefix: "your_page_name",
+  buildPath: (index, pathPrefix) => index > 1 ? `${pathPrefix}/${index}` : `/${pathPrefix}` // This is optional and this is the default
 }}
 ```
 
@@ -138,6 +132,7 @@ Then...
 
 * Create a template in tha same way as above but this time
 * Add a `pathPrefix`
+* (optional) add `buildPath` if you want to have more control over the pagination URL structure
 
 In this instance a new set of pages will be created at the following path `your_site/your_page_name`
 Then a second paginated page of `your_site/your_page_name/2`

--- a/src/index.js
+++ b/src/index.js
@@ -12,19 +12,18 @@ const filterPages = (posts, pageLength) => {
 
 const getPageIndex = index => (index === 0 ? "" : index + 1);
 
-const buildPaginationRoute = (index, pathPrefix) => {
-  return index > 1 ? `${pathPrefix}/${index}` : `/${pathPrefix}`
-}
+const buildPaginationRoute = (index, pathPrefix) => index > 1 ? `${pathPrefix}/${index}` : `/${pathPrefix}`
 
 const isFirstPage = index => (index === 0 ? true : false);
 
 const isLastPage = (index, groups) =>
   index === groups.length - 1 ? true : false;
 
-const createPaginatedPages = (posts, createPage, template, pathPrefix) => {
+const createPaginatedPages = (posts, createPage, template, pathPrefix, buildPath) => {
   posts.forEach((group, index, groups) => {
+    const pageIndex = getPageIndex(index)
     return createPage({
-      path: buildPaginationRoute(getPageIndex(index), pathPrefix),
+      path: typeof buildPath === 'function' ? buildPath(pageIndex, pathPrefix) : buildPaginationRoute(pageIndex, pathPrefix),
       component: template,
       context: {
         group,
@@ -43,13 +42,15 @@ module.exports = ({
   createPage,
   pageTemplate,
   pageLength = 10,
-  pathPrefix = ""
+  pathPrefix = "",
+  buildPath = null
 }) => {
   const paginationTemplate = path.resolve(pageTemplate);
   createPaginatedPages(
     filterPages(edges, pageLength),
     createPage,
     paginationTemplate,
-    pathPrefix
+    pathPrefix,
+    buildPath
   );
 };


### PR DESCRIPTION
This was mentioned briefly in https://github.com/pixelstew/gatsby-paginate/pull/7#issuecomment-349248456 & I think it's the best solution, especially after merging #12 which breaks my usage.

This change is backward compatible if nothing is passed it will fallback to the normal behavior.

Also removed some git conflicts from the readme file.