### PR TITLE
Add ability to pass through optional additional context

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ Notice that `createPaginatedPages` is being passed an options object.
 3. `pageTemplate` is a template to use for the index page. And
 4. `pageLength` is an optional parameter that defines how many posts to show per index page. It defaults to 10.
 5. `pathPrefix` is an optional parameter for passing the name of a path to add to the path generated in the `createPage`func. This is used in [use case 2](#eg2) below.
-6. `context` is an optional parameter which is used as the `context` property when `createPage` is called. It cannot include the property `pagination`.
+6. `context` is an optional parameter which is used as the `context` property when `createPage` is called.
 
 `createPaginatedPages` will then call `createPage` to create an index page for each of the groups of pages. The content that describes the blogs (title, slug, etc) that will go in each page will be passed to the template through `props.pathContext` so you need to make sure that everything that you want on the index page regarding the blogs should be requested in the GraphQL query in `gatsby-node.js`.
 
@@ -143,13 +143,14 @@ Then a second paginated page of `your_site/your_page_name/2`
 
 This is a simple template which might be used in [use case 1](#eg1) above to replace the index of a blog with a paginated list of posts.
 
-The `pathContext.pagination` object which contains the following 5 keys is passed to the template;
+The `pathContext` object which contains the following 5 keys is passed to the template;
 
 1. `group` - (arr) an array containing the number of edges/nodes specified in the `pageLength` option.
 1. `index` - (int) this is the index of the edge/node.
 1. `first` - (bool) **Soon to be deprecated - please calculate first using index and pageCount** - is this the first page?
 1. `last` - (bool) **Soon to be deprecated - please calculate last using index and pageCount** - is this the last page?
 1. `pageCount` - (int) the total count of items edges/nodes being paginated through
+1. `additionalContext` - (obj) optional additional context
 
 ```javascript
 import React, { Component } from "react";

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,8 @@ const createPaginatedPages = (
         first: isFirstPage(index),
         last: isLastPage(index, groups),
         index: index + 1,
-        pageCount: groups.length
+        pageCount: groups.length,
+        additionalContext: context
       })
     });
   });


### PR DESCRIPTION
I realise #17 was removed because it wasn't backwards compatible however, it would be really useful to be able to pass through custom context. I have re-added it in a backward compatible and completely optional way.