### PR TITLE
Index plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description":
     "This is a small library for paginating an array of posts within gatsby js",
   "main": "./src/index.js",
-  "keywords": ["gatsby"],
+  "keywords": ["gatsby", "gatsby-plugin"],
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search. 

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310