### PR TITLE
added layout fix to the gatsby-paginate api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ module.exports = ({
   pathPrefix = "",
   buildPath = null,
   context = {},
-  layout
+  layout = 'index'
 }) => {
   const paginationTemplate = path.resolve(pageTemplate);
   createPaginatedPages(
@@ -69,6 +69,6 @@ module.exports = ({
     pathPrefix,
     buildPath,
     context,
-    index
+    layout
   );
 };


### PR DESCRIPTION
I was attempting to use this package and I was getting an error that index is not defined. See my comment in #28.

This PR should take care of that issue. I believe what is actually intended is that the default layout should be `index`.

Let me know if I am missing the mark with this one.