### PR TITLE
Docs: Fix example Posts to Pages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ const IndexPage = ({ data, pathContext }) => {
 
   return (
     <div>
-      <h4>{pageCount} Posts</h4>
+      <h4>{pageCount} Pages</h4>
 
       {group.map(({ node }) => (
         <div key={node.id} className="blogListing">


### PR DESCRIPTION
Fix template example, replacing `Posts` with `Pages` since `{pageCount}` represents the page count.