### PR TITLE
Fixes problem with empty path when there's no pathprefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,12 @@ const createGroups = (pages, pageLength) =>
 
 const getPageIndex = index => (index === 0 ? `` : index + 1)
 
-const buildPaginationRoute = (index, pathPrefix) =>
-  index > 1 ? `${pathPrefix}/${index}` : pathPrefix
+const buildPaginationRoute = (index, pathPrefix) => {
+  if (!index && !path) {
+    return `/`
+  }
+  return index > 1 ? `${pathPrefix}/${index}` : pathPrefix
+}
 
 const isFirstPage = index => index === 0
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ const getPageIndex = index => (index === 0 ? `` : index + 1)
 const buildPaginationRoute = (index, pathPrefix) => 
   index > 1 ? `${pathPrefix}/${index}` : (pathPrefix || `/`)
 
-
 const isFirstPage = index => index === 0
 
 const isLastPage = (index, length) => index === length - 1

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,9 @@ const createGroups = (pages, pageLength) =>
 
 const getPageIndex = index => (index === 0 ? `` : index + 1)
 
-const buildPaginationRoute = (index, pathPrefix) => {
-  if (!index && !path) {
-    return `/`
-  }
-  return index > 1 ? `${pathPrefix}/${index}` : pathPrefix
-}
+const buildPaginationRoute = (index, pathPrefix) => 
+  index > 1 ? `${pathPrefix}/${index}` : (pathPrefix || `/`)
+
 
 const isFirstPage = index => index === 0
 


### PR DESCRIPTION
fixes #46 

We should return an `/` for the homepage when there's no empty path prefix. 